### PR TITLE
BrowserModule needed to be referenced for rc6. Tests still broken.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "homepage": "https://github.com/dougludlow/ng2-bs3-modal#readme",
   "devDependencies": {
-    "@angular/common": "2.0.0-rc.5",
-    "@angular/compiler": "2.0.0-rc.5",
-    "@angular/core": "2.0.0-rc.5",
-    "@angular/platform-browser": "2.0.0-rc.5",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.5",
-    "@angular/router": "3.0.0-beta.2",
+    "@angular/common": "2.0.0-rc.6",
+    "@angular/compiler": "2.0.0-rc.6",
+    "@angular/core": "2.0.0-rc.6",
+    "@angular/platform-browser": "2.0.0-rc.6",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.6",
+    "@angular/router": "3.0.0-rc.2",
     "bootstrap": "^3.3.6",
     "es6-shim": "^0.35.0",
     "jasmine": "^2.4.1",
@@ -62,11 +62,11 @@
     "zone.js": "^0.6.12"
   },
   "peerDependencies": {
-    "@angular/common": "2.0.0-rc.5",
-    "@angular/compiler": "2.0.0-rc.5",
-    "@angular/core": "2.0.0-rc.5",
-    "@angular/platform-browser": "2.0.0-rc.5",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.5",
+    "@angular/common": "2.0.0-rc.6",
+    "@angular/compiler": "2.0.0-rc.6",
+    "@angular/core": "2.0.0-rc.6",
+    "@angular/platform-browser": "2.0.0-rc.6",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.6",
     "bootstrap": "~3.3.x"
   }
 }

--- a/src/ng2-bs3-modal/components/modal-footer.ts
+++ b/src/ng2-bs3-modal/components/modal-footer.ts
@@ -13,7 +13,7 @@ import { ModalComponent } from './modal';
 })
 export class ModalFooterComponent {
     @Input('show-default-buttons') showDefaultButtons: boolean = false;
-    @Input('dismiss-button-label') dismissButtonLabel: string = "Dismiss";
-    @Input('close-button-label') closeButtonLabel: string = "Close";
+    @Input('dismiss-button-label') dismissButtonLabel: string = 'Dismiss';
+    @Input('close-button-label') closeButtonLabel: string = 'Close';
     constructor(private modal: ModalComponent) { }
 }

--- a/src/ng2-bs3-modal/ng2-bs3-modal.ts
+++ b/src/ng2-bs3-modal/ng2-bs3-modal.ts
@@ -1,4 +1,5 @@
 import { NgModule, Type } from '@angular/core';
+import { BrowserModule  } from '@angular/platform-browser';
 
 import { ModalComponent } from './components/modal';
 import { ModalHeaderComponent } from './components/modal-header';
@@ -21,6 +22,7 @@ export const MODAL_DIRECTIVES: Type<any>[] = [
 ];
 
 @NgModule({
+    imports: [BrowserModule],
     declarations: MODAL_DIRECTIVES,
     exports: MODAL_DIRECTIVES
 })


### PR DESCRIPTION
I've been using your fork of dougludlow's project in a project of my own. To get it to work with RC6, I had to add the BrowserModule to the ng2-bs3-modal module. Otherwise, the templates in the module don't render right when I reference it in a parent module.

I didn't have time to fix the tests, but this should be working on RC6 now...
